### PR TITLE
Correcting the decompression

### DIFF
--- a/src/android/Zip.java
+++ b/src/android/Zip.java
@@ -120,6 +120,7 @@ public class Zip extends CordovaPlugin {
             {
                 anyEntries = true;
                 String compressedName = ze.getName();
+                 compressedName = compressedName.replace("\\", "/");
 
                 if (ze.isDirectory()) {
                    File dir = new File(outputDirectory + compressedName);


### PR DESCRIPTION
Correcting the decompression of a zip with directories.example:
a zip that has the directories
--d1
---- d1.d2
------ d1.d2.d3

the decompression was so
d1\d1.d2\d1.d2.d3

this was a filename

with the correction will be

d1/d1.d2 /d1.d2.d3